### PR TITLE
#19 Fix `publish` command

### DIFF
--- a/src/SolarWinds.Changesets/CHANGELOG.md
+++ b/src/SolarWinds.Changesets/CHANGELOG.md
@@ -1,5 +1,14 @@
 # SolarWinds.Changesets
 
+## 0.1.4
+
+**Patch Changes**:
+
+- [[#19](https://github.com/solarwinds/net-changesets/issues/19)] Fix publish command ([PR #14](https://github.com/solarwinds/net-changesets/pull/14))
+  - The `publish` command now compares the last two commits (HEAD~1 and HEAD) instead of comparing the last commit with the working tree to determine which projects were published.
+    This change is required because publishing must be done after version bumps and generated files are committed. Since there is no other reliable way to detect whether the version command was run before publish,
+    the comparison is based on committed changes in `.csproj` files. This is still error-prone if users make manual changes to `.csproj` files and run `publish` command, but it is a reasonable compromise for now.
+
 ## 0.1.3
 
 **Patch Changes**:

--- a/src/SolarWinds.Changesets/Commands/Publish/PublishChangesetCommand.cs
+++ b/src/SolarWinds.Changesets/Commands/Publish/PublishChangesetCommand.cs
@@ -1,4 +1,4 @@
-using SolarWinds.Changesets.Services;
+using SolarWinds.Changesets.Commands.Publish.Services;
 using SolarWinds.Changesets.Shared;
 using Spectre.Console;
 using Spectre.Console.Cli;

--- a/src/SolarWinds.Changesets/Commands/Publish/PublishChangesetCommand.cs
+++ b/src/SolarWinds.Changesets/Commands/Publish/PublishChangesetCommand.cs
@@ -40,7 +40,7 @@ internal sealed class PublishChangesetCommand : ConfigurationCommandBase
         _console.WriteLine("Determining projects to publish ...");
         _console.WriteLine();
 
-        ProcessOutput processOutput = await _gitService.GetDiff(ChangesetConfig.SourcePath);
+        ProcessOutput processOutput = await _gitService.GetDiff(Constants.WorkingDirectoryFullPath, ChangesetConfig.SourcePath);
         List<string> changedCsharpProjectNames = processOutput.Output.Where(x => x.Contains(".csproj", StringComparison.Ordinal)).ToList();
 
         if (changedCsharpProjectNames.Count == 0)

--- a/src/SolarWinds.Changesets/Commands/Publish/Services/DotnetService.cs
+++ b/src/SolarWinds.Changesets/Commands/Publish/Services/DotnetService.cs
@@ -1,6 +1,6 @@
 using SolarWinds.Changesets.Shared;
 
-namespace SolarWinds.Changesets.Services;
+namespace SolarWinds.Changesets.Commands.Publish.Services;
 
 /// <inheritdoc />
 public sealed class DotnetService : IDotnetService

--- a/src/SolarWinds.Changesets/Commands/Publish/Services/GitService.cs
+++ b/src/SolarWinds.Changesets/Commands/Publish/Services/GitService.cs
@@ -19,12 +19,12 @@ public sealed class GitService : IGitService
     }
 
     /// <inheritdoc />
-    public async Task<ProcessOutput> GetDiff(string sourcePath)
+    public async Task<ProcessOutput> GetDiff(string workingDirectory, string sourcePath)
     {
         return await _processExecutor.Execute(
             "git",
-            $"diff --name-only HEAD~1 HEAD -- '*.csproj' {sourcePath}",
-            Constants.WorkingDirectoryFullPath
+            $"diff --name-only HEAD~1 HEAD {sourcePath}",
+            workingDirectory
         );
     }
 }

--- a/src/SolarWinds.Changesets/Commands/Publish/Services/GitService.cs
+++ b/src/SolarWinds.Changesets/Commands/Publish/Services/GitService.cs
@@ -1,6 +1,6 @@
 using SolarWinds.Changesets.Shared;
 
-namespace SolarWinds.Changesets.Services;
+namespace SolarWinds.Changesets.Commands.Publish.Services;
 
 /// <inheritdoc />
 public sealed class GitService : IGitService
@@ -23,7 +23,7 @@ public sealed class GitService : IGitService
     {
         return await _processExecutor.Execute(
             "git",
-            $"diff --name-only {sourcePath}",
+            $"diff --name-only HEAD~1 HEAD -- '*.csproj' {sourcePath}",
             Constants.WorkingDirectoryFullPath
         );
     }

--- a/src/SolarWinds.Changesets/Commands/Publish/Services/IDotnetService.cs
+++ b/src/SolarWinds.Changesets/Commands/Publish/Services/IDotnetService.cs
@@ -1,6 +1,6 @@
 using SolarWinds.Changesets.Shared;
 
-namespace SolarWinds.Changesets.Services;
+namespace SolarWinds.Changesets.Commands.Publish.Services;
 
 /// <summary>
 /// Provides functionality to interact with the .NET CLI for operations such as packing and publishing NuGet packages.

--- a/src/SolarWinds.Changesets/Commands/Publish/Services/IGitService.cs
+++ b/src/SolarWinds.Changesets/Commands/Publish/Services/IGitService.cs
@@ -10,7 +10,8 @@ public interface IGitService
     /// <summary>
     /// Retrieves a list of file names that have changed in the specified source path.
     /// </summary>
+    /// <param name="workingDirectory">Working directory.</param>
     /// <param name="sourcePath">The path to check for file differences.</param>
     /// <returns>Process output and exit code.</returns>
-    Task<ProcessOutput> GetDiff(string sourcePath);
+    Task<ProcessOutput> GetDiff(string workingDirectory, string sourcePath);
 }

--- a/src/SolarWinds.Changesets/Commands/Publish/Services/IGitService.cs
+++ b/src/SolarWinds.Changesets/Commands/Publish/Services/IGitService.cs
@@ -1,6 +1,6 @@
 using SolarWinds.Changesets.Shared;
 
-namespace SolarWinds.Changesets.Services;
+namespace SolarWinds.Changesets.Commands.Publish.Services;
 
 /// <summary>
 /// Provides Git-related services, such as retrieving file differences.

--- a/src/SolarWinds.Changesets/Program.cs
+++ b/src/SolarWinds.Changesets/Program.cs
@@ -2,11 +2,11 @@ using Microsoft.Extensions.DependencyInjection;
 using SolarWinds.Changesets.Commands.Add;
 using SolarWinds.Changesets.Commands.Init;
 using SolarWinds.Changesets.Commands.Publish;
+using SolarWinds.Changesets.Commands.Publish.Services;
 using SolarWinds.Changesets.Commands.Status;
 using SolarWinds.Changesets.Commands.Version;
 using SolarWinds.Changesets.Commands.Version.Helpers;
 using SolarWinds.Changesets.Infrastructure;
-using SolarWinds.Changesets.Services;
 using SolarWinds.Changesets.Shared;
 using Spectre.Console.Cli;
 

--- a/src/SolarWinds.Changesets/Shared/Semver.cs
+++ b/src/SolarWinds.Changesets/Shared/Semver.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using SystemVersion = System.Version;
 
 namespace SolarWinds.Changesets.Shared;
@@ -45,13 +46,27 @@ internal sealed class Semver
         return $"{Major}.{Minor}.{Patch}";
     }
 
-    public static Semver? FromString(string version)
+    /// <summary>
+    /// Attempts to parse a version string into a <see cref="Semver"/> instance.
+    /// </summary>
+    /// <param name="version">The version string to parse (e.g., "1.2.3").</param>
+    /// <param name="semver">When this method returns, contains the parsed <see cref="Semver"/> if parsing succeeded, or null if parsing failed.</param>
+    /// <returns>True if the version string was successfully parsed; otherwise, false.</returns>
+    public static bool TryParse(string version, [NotNullWhen(true)] out Semver? semver)
     {
-        if (!SystemVersion.TryParse(version, out SystemVersion? result))
+        if (SystemVersion.TryParse(version, out SystemVersion? result))
         {
-            return null;
+            semver = new(result.Major, result.Minor, result.Build);
+            return true;
         }
 
-        return new(result.Major, result.Minor, result.Build);
+        semver = null;
+        return false;
     }
+
+    /// <summary>
+    /// Gets an empty <see cref="Semver"/> instance with version 0.0.0.
+    /// </summary>
+    /// <value>A <see cref="Semver"/> instance representing version 0.0.0.</value>
+    public static Semver Empty { get; } = new(0, 0, 0);
 }

--- a/src/SolarWinds.Changesets/SolarWinds.Changesets.csproj
+++ b/src/SolarWinds.Changesets/SolarWinds.Changesets.csproj
@@ -17,7 +17,7 @@
     <PackageReleaseNotes>$(RepositoryUrl)/releases</PackageReleaseNotes>
     <PackAsTool>true</PackAsTool>
     <OutputType>Exe</OutputType>
-    <Version>0.1.3</Version>
+    <Version>0.1.4</Version>
 
     <DebugType>embedded</DebugType>
     <EnablePackageValidation>true</EnablePackageValidation>

--- a/tests/SolarWinds.Changesets.Tests/Publish/GitServiceTests.cs
+++ b/tests/SolarWinds.Changesets.Tests/Publish/GitServiceTests.cs
@@ -1,0 +1,184 @@
+using AwesomeAssertions;
+using SolarWinds.Changesets.Commands.Publish.Services;
+using SolarWinds.Changesets.Shared;
+
+namespace SolarWinds.Changesets.Tests.Publish;
+
+[TestFixture]
+internal sealed class GitServiceTests
+{
+    private string _tempRepositoryAbsolutePath = string.Empty;
+    private ProcessExecutor _processExecutor = null!;
+    private GitService _gitService = null!;
+
+    [SetUp]
+    public async Task SetUp()
+    {
+        string testDirectory = TestContext.CurrentContext.TestDirectory;
+        _tempRepositoryAbsolutePath = Path.Join(testDirectory, $"git-service-test-{Guid.NewGuid()}");
+        Directory.CreateDirectory(_tempRepositoryAbsolutePath);
+
+        _processExecutor = new ProcessExecutor();
+        await ExecuteGitCommand("init");
+        await ExecuteGitCommand("config --local user.email \"test@example.com\"");
+        await ExecuteGitCommand("config --local user.name \"Test User\"");
+        await ExecuteGitCommand("config --local commit.gpgSign false");
+
+        _gitService = new GitService(_processExecutor);
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        if (Directory.Exists(_tempRepositoryAbsolutePath))
+        {
+            DeleteDirectoryWithRetry(_tempRepositoryAbsolutePath);
+        }
+    }
+
+    [Test]
+    public async Task GetDiff_WithModifiedCsprojFile_ReturnsModifiedProject()
+    {
+        // Arrange
+        string projectName = "TestProject";
+        string csprojAbsolutePath = Path.Join(_tempRepositoryAbsolutePath, $"{projectName}.csproj");
+
+        // Create initial .csproj file
+        await File.WriteAllTextAsync(csprojAbsolutePath, """
+            <Project Sdk="Microsoft.NET.Sdk">
+              <PropertyGroup>
+                <TargetFramework>net8.0</TargetFramework>
+                <VersionPrefix>1.0.0</VersionPrefix>
+              </PropertyGroup>
+            </Project>
+        """
+        );
+
+        await ExecuteGitCommand("add .");
+        await ExecuteGitCommand("commit -m \"Initial commit\"");
+
+        // Modify .csproj file
+        await File.WriteAllTextAsync(csprojAbsolutePath, """
+            <Project Sdk="Microsoft.NET.Sdk">
+              <PropertyGroup>
+                <TargetFramework>net8.0</TargetFramework>
+                <VersionPrefix>1.1.0</VersionPrefix>
+              </PropertyGroup>
+            </Project>
+        """
+        );
+
+        await ExecuteGitCommand("add .");
+        await ExecuteGitCommand("commit -m \"Update version\"");
+
+        // Act
+        ProcessOutput result = await _gitService.GetDiff(_tempRepositoryAbsolutePath, string.Empty);
+
+        // Assert
+        result.ExitCode.Should().Be(0);
+        result.Output.Should().HaveCount(1);
+        result.Output.First().Should().EndWith($"{projectName}.csproj");
+    }
+
+    [Test]
+    public async Task GetDiff_WithNonCsprojChanges_ReturnsEmpty()
+    {
+        // Arrange
+        string readmePath = Path.Join(_tempRepositoryAbsolutePath, "README.md");
+
+        await File.WriteAllTextAsync(readmePath, "# Test");
+        await ExecuteGitCommand("add .");
+        await ExecuteGitCommand("commit -m \"Initial commit\"");
+
+        await File.WriteAllTextAsync(readmePath, "# Test Updated");
+        await ExecuteGitCommand("add .");
+        await ExecuteGitCommand("commit -m \"Update README\"");
+
+        // Act
+        ProcessOutput result = await _gitService.GetDiff(_tempRepositoryAbsolutePath, string.Empty);
+
+        // Assert
+        result.ExitCode.Should().Be(0);
+        result.Output.Should().HaveCount(1);
+        result.Output.First().Should().EndWith($".md");
+    }
+
+    [Test]
+    public async Task GetDiff_WithMultipleCsprojFiles_ReturnsAllModified()
+    {
+        // Arrange
+        string project1Path = Path.Join(_tempRepositoryAbsolutePath, "Project1.csproj");
+        string project2Path = Path.Join(_tempRepositoryAbsolutePath, "Project2.csproj");
+
+        await File.WriteAllTextAsync(project1Path, "<Project />");
+        await File.WriteAllTextAsync(project2Path, "<Project />");
+        await ExecuteGitCommand("add .");
+        await ExecuteGitCommand("commit -m \"Initial commit\"");
+
+        await File.WriteAllTextAsync(project1Path, "<Project><PropertyGroup /></Project>");
+        await File.WriteAllTextAsync(project2Path, "<Project><PropertyGroup /></Project>");
+        await ExecuteGitCommand("add .");
+        await ExecuteGitCommand("commit -m \"Update projects\"");
+
+        // Act
+        ProcessOutput result = await _gitService.GetDiff(_tempRepositoryAbsolutePath, string.Empty);
+
+        // Assert
+        result.ExitCode.Should().Be(0);
+        result.Output.Should().HaveCount(2);
+        result.Output.Any(p => p.EndsWith("Project1.csproj", StringComparison.InvariantCulture)).Should().BeTrue();
+        result.Output.Any(p => p.EndsWith("Project2.csproj", StringComparison.InvariantCulture)).Should().BeTrue();
+    }
+
+    /// <summary>
+    /// Helper method to execute git commands in the test repository using ProcessExecutor.
+    /// </summary>
+    private async Task ExecuteGitCommand(string arguments)
+    {
+        ProcessOutput result = await _processExecutor.Execute("git", arguments, _tempRepositoryAbsolutePath);
+
+        if (result.ExitCode != 0)
+        {
+            throw new InvalidOperationException($"Git command failed: {arguments}. {result.Output}");
+        }
+    }
+
+    /// <summary>
+    /// Deletes a directory with retry logic to handle file locks from Git processes.
+    /// </summary>
+    private static void DeleteDirectoryWithRetry(string path, int maxRetries = 3)
+    {
+        for (int i = 0; i < maxRetries; i++)
+        {
+            try
+            {
+                Directory.Delete(path, recursive: true);
+                return;
+            }
+            catch (IOException) when (i < maxRetries - 1)
+            {
+                // Wait for file handles to be released
+                Thread.Sleep(100);
+            }
+            catch (UnauthorizedAccessException) when (i < maxRetries - 1)
+            {
+                // Remove read-only attributes and retry
+                RemoveReadOnlyAttributes(path);
+                Thread.Sleep(100);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Removes read-only attributes from all files in a directory recursively.
+    /// </summary>
+    private static void RemoveReadOnlyAttributes(string path)
+    {
+        DirectoryInfo directory = new(path);
+
+        foreach (FileInfo file in directory.GetFiles("*", SearchOption.AllDirectories))
+        {
+            file.Attributes &= ~FileAttributes.ReadOnly;
+        }
+    }
+}

--- a/tests/SolarWinds.Changesets.Tests/Publish/PublishChangesetCommandTests.cs
+++ b/tests/SolarWinds.Changesets.Tests/Publish/PublishChangesetCommandTests.cs
@@ -46,7 +46,7 @@ internal sealed class PublishChangesetCommandTests
     [Test]
     public void PublishChangesetCommand_CompletesSuccesfully_HappyPath()
     {
-        _gitServiceMock.Setup(x => x.GetDiff(It.IsAny<string>())).Returns(Task.FromResult(new ProcessOutput(["A.csproj", "B.csproj"], 0)));
+        _gitServiceMock.Setup(x => x.GetDiff(It.IsAny<string>(), It.IsAny<string>())).Returns(Task.FromResult(new ProcessOutput(["A.csproj", "B.csproj"], 0)));
         _dotnetServiceMock.Setup(x => x.Pack(It.IsAny<string>())).Returns(Task.FromResult(new ProcessOutput(["Project A packed", "Project B packed"], 0)));
         _dotnetServiceMock.Setup(x => x.Publish(It.IsAny<string>())).Returns(Task.FromResult(new ProcessOutput(["Project A published", "Project B published"], 0)));
 
@@ -58,7 +58,7 @@ internal sealed class PublishChangesetCommandTests
     [Test]
     public void PublishChangesetCommand_WhenNoCsprojToPublish_FinishesWithError()
     {
-        _gitServiceMock.Setup(x => x.GetDiff(It.IsAny<string>())).Returns(Task.FromResult(new ProcessOutput([], 0)));
+        _gitServiceMock.Setup(x => x.GetDiff(It.IsAny<string>(), It.IsAny<string>())).Returns(Task.FromResult(new ProcessOutput([], 0)));
 
         CommandAppResult result = _app.Run();
 
@@ -68,7 +68,7 @@ internal sealed class PublishChangesetCommandTests
     [Test]
     public void PublishChangesetCommand_WhenPublishFails_FinishesWithError()
     {
-        _gitServiceMock.Setup(x => x.GetDiff(It.IsAny<string>())).Returns(Task.FromResult(new ProcessOutput(["A.csproj", "B.csproj"], 0)));
+        _gitServiceMock.Setup(x => x.GetDiff(It.IsAny<string>(), It.IsAny<string>())).Returns(Task.FromResult(new ProcessOutput(["A.csproj", "B.csproj"], 0)));
         _dotnetServiceMock.Setup(x => x.Pack(It.IsAny<string>())).Returns(Task.FromResult(new ProcessOutput(["Project A packed", "Project B packed"], 0)));
         _dotnetServiceMock.Setup(x => x.Publish(It.IsAny<string>())).Returns(Task.FromResult(new ProcessOutput(["Some error ..."], 1)));
 

--- a/tests/SolarWinds.Changesets.Tests/Publish/PublishChangesetCommandTests.cs
+++ b/tests/SolarWinds.Changesets.Tests/Publish/PublishChangesetCommandTests.cs
@@ -2,8 +2,8 @@ using Microsoft.Extensions.DependencyInjection;
 using Moq;
 using SolarWinds.Changesets.Commands.Init;
 using SolarWinds.Changesets.Commands.Publish;
+using SolarWinds.Changesets.Commands.Publish.Services;
 using SolarWinds.Changesets.Infrastructure;
-using SolarWinds.Changesets.Services;
 using SolarWinds.Changesets.Shared;
 using Spectre.Console.Testing;
 

--- a/tests/SolarWinds.Changesets.Tests/Version/CsProjectsRepositoryTests.cs
+++ b/tests/SolarWinds.Changesets.Tests/Version/CsProjectsRepositoryTests.cs
@@ -36,7 +36,7 @@ internal sealed class CsProjectsRepositoryTests
                 ModuleCsProjFilePath = s_testFilePath,
                 Changes = [("abc", BumpType.Minor)]
             }];
-        TestConsole testConsole = new();
+        using TestConsole testConsole = new();
         CsProjectsRepository csProjFileHelper = new(testConsole);
 
         await csProjFileHelper.UpdateCsProjectsVersionAsync(changes);
@@ -44,7 +44,6 @@ internal sealed class CsProjectsRepositoryTests
         Semver? versionFromFile = LoadVersionFromProjectFile(s_testFilePath);
 
         versionFromFile?.Should().BeEquivalentTo(new Semver(1, 1, 0));
-        testConsole.Dispose();
     }
 
     [Test]
@@ -65,7 +64,7 @@ internal sealed class CsProjectsRepositoryTests
                 Changes = [("abc", BumpType.Minor)]
             }];
 
-        TestConsole testConsole = new();
+        using TestConsole testConsole = new();
         CsProjectsRepository csProjFileHelper = new(testConsole);
 
         await csProjFileHelper.UpdateCsProjectsVersionAsync(changes);
@@ -73,7 +72,6 @@ internal sealed class CsProjectsRepositoryTests
         LoadVersionFromProjectFile(s_testFilePath).Should().BeNull();
 
         ComputeFileHash(s_testFilePath).Should().Be(hashOriginal);
-        testConsole.Dispose();
     }
 
     [Test]
@@ -84,7 +82,7 @@ internal sealed class CsProjectsRepositoryTests
             SourcePath = "TestData"
         };
 
-        TestConsole testConsole = new();
+        using TestConsole testConsole = new();
         CsProjectsRepository csProjFileHelper = new(testConsole);
 
         CsProject[] csProjects = csProjFileHelper.GetCsProjects(config);
@@ -97,8 +95,6 @@ internal sealed class CsProjectsRepositoryTests
             .Should()
             .Be(2)
             ;
-
-        testConsole.Dispose();
     }
 
     private static void DeleteFile(string path)

--- a/tests/SolarWinds.Changesets.Tests/Version/CsProjectsRepositoryTests.cs
+++ b/tests/SolarWinds.Changesets.Tests/Version/CsProjectsRepositoryTests.cs
@@ -77,7 +77,7 @@ internal sealed class CsProjectsRepositoryTests
     }
 
     [Test]
-    public void GetCsProjects_OneVersionOneWithoutVersionProjects_ReturnsTwoProjects()
+    public void GetCsProjects_OnlyOneProjectWithValidVersion_ReturnsSingleProject()
     {
         ChangesetConfig config = new()
         {
@@ -88,11 +88,10 @@ internal sealed class CsProjectsRepositoryTests
         CsProjectsRepository csProjFileHelper = new(testConsole);
 
         CsProject[] csProjects = csProjFileHelper.GetCsProjects(config);
-        csProjects.Length.Should().Be(2);
+        csProjects.Length.Should().Be(1);
 
         csProjects
-            .Where(x => x.Name == "TestProjectWithVersion")
-            .First()
+            .Single()
             .ReferencedProjectNames
             .Length
             .Should()
@@ -116,8 +115,12 @@ internal sealed class CsProjectsRepositoryTests
         doc.Load(path);
 
         XmlNode? versionNode = doc.DocumentElement?.SelectSingleNode("/Project/PropertyGroup/Version");
+        if (versionNode != null && Semver.TryParse(versionNode.InnerText, out Semver? parsedVersion))
+        {
+            return parsedVersion;
+        }
 
-        return versionNode != null ? Semver.FromString(versionNode.InnerText) : null;
+        return null;
     }
 
     private static string ComputeFileHash(string path)

--- a/tests/SolarWinds.Changesets.Tests/Version/VersionChangesetCommandTests.cs
+++ b/tests/SolarWinds.Changesets.Tests/Version/VersionChangesetCommandTests.cs
@@ -57,6 +57,8 @@ internal sealed class VersionChangesetCommandTests
 
         CommandAppResult result = app.Run();
 
+        result.ExitCode.Should().Be(ResultCodes.Success, result.Output);
+
         AssertVersionOutput();
     }
 

--- a/tests/SolarWinds.Changesets.Tests/Version/VersionChangesetCommandTests.cs
+++ b/tests/SolarWinds.Changesets.Tests/Version/VersionChangesetCommandTests.cs
@@ -80,8 +80,12 @@ internal sealed class VersionChangesetCommandTests
         doc.Load(path);
 
         XmlNode? versionNode = doc.DocumentElement?.SelectSingleNode("/Project/PropertyGroup/Version");
+        if (versionNode != null && Semver.TryParse(versionNode.InnerText, out Semver? parsedVersion))
+        {
+            return parsedVersion;
+        }
 
-        return versionNode != null ? Semver.FromString(versionNode.InnerText) : null;
+        return null;
     }
 
     private static void CopyDirectory(string sourceDirectory, string destinationDirectory, bool recursive, bool firstRun)


### PR DESCRIPTION
# Issue number
#19 

# Changes
Please review PR by individual commits.

The `publish` command now compares the last two commits (HEAD~1 and HEAD) instead of comparing the last commit with the working tree to determine which projects were published.
    This change is required because publishing must be done after version bumps and generated files are committed. Since there is no other reliable way to detect whether the version command was run before publish, the comparison must be based on committed changes.

Also last 5 code scanning alerts were fixed: https://github.com/solarwinds/net-changesets/security/code-scanning

# Checklist

- [x] I have double-checked my own changes
- [x] I have read the [Contribution Guidelines](https://github.com/solarwinds/net-changesets/blob/main/CONTRIBUTING.md)
- [x] Include the issue number (#xxx) in the branch name, PR title, and PR description in the Issue number section above
- [x] Provide a reasonable description of the PR in the [Changes](#changes) section
- [x] I have commented on the issue above and discussed the intended changes
- [x] All newly added code is adequately covered by tests
- [x] Make sure your PR is passing the CI/CD pipeline
- [x] The documentation was modified to reflect the changes _OR_ No documentation changes are required.